### PR TITLE
Fixed Line 636 that was causing error in PHP 8.0

### DIFF
--- a/push_story.php
+++ b/push_story.php
@@ -633,16 +633,18 @@ function nprstory_save_datetime( $post_ID ) {
 	$time = ( isset( $_POST['nprone-expiry-time'] ) ) ? sanitize_text_field( $_POST['nprone-expiry-time'] ) : '00:00';
 
 	// If the post is not published and values are not set, save an empty post meta
-	if ( isset( $date ) && 'publish' === $post->status ) {
-		$timezone = get_option( 'gmt_offset' );
-		$datetime = date_create( $date, nprstory_get_datetimezone() );
-		$time = explode( ':', $time );
-		$datetime->setTime( $time[0], $time[1] );
-		$value = date_format( $datetime, DATE_ATOM );
-		update_post_meta( $post_ID, '_nprone_expiry_8601', $value );
-	} else {
-		delete_post_meta( $post_ID, '_nprone_expiry_8601' );
-	}
+	if (isset($date) && !empty($date)) {
+		if ('publish' === $post->status ) {
+			$timezone = get_option( 'gmt_offset' );
+			$datetime = date_create( $date, nprstory_get_datetimezone() );
+			$time = explode( ':', $time );
+			$datetime->setTime( $time[0], $time[1] );
+			$value = date_format( $datetime, DATE_ATOM );
+			update_post_meta( $post_ID, '_nprone_expiry_8601', $value );
+		} else {
+			delete_post_meta( $post_ID, '_nprone_expiry_8601' );
+		}
+	}	
 }
 add_action( 'save_post', 'nprstory_save_datetime');
 

--- a/push_story.php
+++ b/push_story.php
@@ -633,18 +633,16 @@ function nprstory_save_datetime( $post_ID ) {
 	$time = ( isset( $_POST['nprone-expiry-time'] ) ) ? sanitize_text_field( $_POST['nprone-expiry-time'] ) : '00:00';
 
 	// If the post is not published and values are not set, save an empty post meta
-	if (isset($post) && !empty($date)) {
-		if ('publish' === $post->status ) {
-			$timezone = get_option( 'gmt_offset' );
-			$datetime = date_create( $date, nprstory_get_datetimezone() );
-			$time = explode( ':', $time );
-			$datetime->setTime( $time[0], $time[1] );
-			$value = date_format( $datetime, DATE_ATOM );
-			update_post_meta( $post_ID, '_nprone_expiry_8601', $value );
-		} else {
-			delete_post_meta( $post_ID, '_nprone_expiry_8601' );
-		}
-	}	
+	if ( isset( $date ) && 'publish' === $post->status ) {
+		$timezone = get_option( 'gmt_offset' );
+		$datetime = date_create( $date, nprstory_get_datetimezone() );
+		$time = explode( ':', $time );
+		$datetime->setTime( $time[0], $time[1] );
+		$value = date_format( $datetime, DATE_ATOM );
+		update_post_meta( $post_ID, '_nprone_expiry_8601', $value );
+	} else {
+		delete_post_meta( $post_ID, '_nprone_expiry_8601' );
+	}
 }
 add_action( 'save_post', 'nprstory_save_datetime');
 

--- a/push_story.php
+++ b/push_story.php
@@ -633,16 +633,18 @@ function nprstory_save_datetime( $post_ID ) {
 	$time = ( isset( $_POST['nprone-expiry-time'] ) ) ? sanitize_text_field( $_POST['nprone-expiry-time'] ) : '00:00';
 
 	// If the post is not published and values are not set, save an empty post meta
-	if ( isset( $date ) && 'publish' === $post->status ) {
-		$timezone = get_option( 'gmt_offset' );
-		$datetime = date_create( $date, nprstory_get_datetimezone() );
-		$time = explode( ':', $time );
-		$datetime->setTime( $time[0], $time[1] );
-		$value = date_format( $datetime, DATE_ATOM );
-		update_post_meta( $post_ID, '_nprone_expiry_8601', $value );
-	} else {
-		delete_post_meta( $post_ID, '_nprone_expiry_8601' );
-	}
+	if (isset($post) && !empty($date)) {
+		if ('publish' === $post->status ) {
+			$timezone = get_option( 'gmt_offset' );
+			$datetime = date_create( $date, nprstory_get_datetimezone() );
+			$time = explode( ':', $time );
+			$datetime->setTime( $time[0], $time[1] );
+			$value = date_format( $datetime, DATE_ATOM );
+			update_post_meta( $post_ID, '_nprone_expiry_8601', $value );
+		} else {
+			delete_post_meta( $post_ID, '_nprone_expiry_8601' );
+		}
+	}	
 }
 add_action( 'save_post', 'nprstory_save_datetime');
 

--- a/readme.txt
+++ b/readme.txt
@@ -11,8 +11,6 @@ Text Domain: nprapi
 
 A collection of tools for reusing content from NPR.org, now maintained and updated by NPR member station developers.
 
-Line of code added to test submodule configuration
-
 == Description ==
 
 The NPR Story API Plugin provides push and pull functionality with the NPR Story API along with a user-friendly administrative interface.

--- a/readme.txt
+++ b/readme.txt
@@ -11,6 +11,8 @@ Text Domain: nprapi
 
 A collection of tools for reusing content from NPR.org, now maintained and updated by NPR member station developers.
 
+Line of code added to test submodule configuration
+
 == Description ==
 
 The NPR Story API Plugin provides push and pull functionality with the NPR Story API along with a user-friendly administrative interface.


### PR DESCRIPTION
Added another if statement to make sure the date is not empty so that it doesn't try to check the $post->status unnecessarily.

This was in regards to https://github.com/OpenPublicMedia/nprapi-wordpress/issues/23